### PR TITLE
fix: Sync pose overlay with exact frame timestamps

### DIFF
--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -31,6 +31,7 @@ def run_pose_estimation(video_path: str):
     Runs in a separate thread to avoid blocking the async event loop.
     """
     results_payload = []
+    timestamps = []
     fps_estimate = 30.0
 
     with mp_pose.Pose(
@@ -49,6 +50,10 @@ def run_pose_estimation(video_path: str):
             success, frame = cap.read()
             if not success:
                 break
+                
+            timestamp = cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0
+            timestamps.append(timestamp)
+
                 
             # Handle video rotation metadata that cv2 sometimes ignores
             # CAP_PROP_ORIENTATION_META was added in newer OpenCV versions
@@ -79,13 +84,18 @@ def run_pose_estimation(video_path: str):
 
         cap.release()
 
+    # Normalize timestamps if the first one is negative or non-zero
+    if timestamps:
+        first_t = timestamps[0]
+        timestamps = [t - first_t for t in timestamps]
+
     processed_count = len(results_payload)
     if total_frames > 0 and processed_count < (total_frames * 0.9):
         raise ValueError(
             f"Video analysis incomplete. Expected {total_frames} frames, but processed {processed_count}."
         )
 
-    return {"pose_data": results_payload, "fps": round(fps_estimate, 2)}
+    return {"pose_data": results_payload, "fps": round(fps_estimate, 2), "timestamps": timestamps}
 
 
 async def analyze_climb(ctx, climb_id: int, file_key: str):

--- a/frontend/src/components/ResultViewer.tsx
+++ b/frontend/src/components/ResultViewer.tsx
@@ -50,6 +50,7 @@ export function ResultViewer({ climb }: ResultViewerProps) {
 
   const poseData = climb.analysis_results?.pose_data || [];
   const fps = climb.analysis_results?.fps || 30;
+  const timestamps = climb.analysis_results?.timestamps;
 
   // --- NEW: Query Client and Delete Mutation ---
   const queryClient = useQueryClient();
@@ -105,7 +106,32 @@ export function ResultViewer({ climb }: ResultViewerProps) {
       const ctx = canvas.getContext("2d");
       if (ctx) {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
-        const frameIndex = Math.floor(video.currentTime * fps);
+        
+        let frameIndex = 0;
+        if (timestamps && timestamps.length > 0) {
+          let low = 0;
+          let high = timestamps.length - 1;
+          const target = video.currentTime;
+          while (low <= high) {
+            const mid = Math.floor((low + high) / 2);
+            if (timestamps[mid] < target) {
+              low = mid + 1;
+            } else if (timestamps[mid] > target) {
+              high = mid - 1;
+            } else {
+              low = mid;
+              break;
+            }
+          }
+          frameIndex = low;
+          if (frameIndex >= timestamps.length) frameIndex = timestamps.length - 1;
+          if (frameIndex > 0 && target - timestamps[frameIndex - 1] < timestamps[frameIndex] - target) {
+            frameIndex = frameIndex - 1;
+          }
+        } else {
+          frameIndex = Math.floor(video.currentTime * fps);
+        }
+
         if (frameIndex < poseData.length) {
           const currentFrame = poseData[frameIndex];
           if (currentFrame) {

--- a/frontend/src/components/UploadManager.tsx
+++ b/frontend/src/components/UploadManager.tsx
@@ -20,6 +20,7 @@ export interface Keypoint {
 export interface AnalysisResults {
   pose_data?: Keypoint[][]; // An array of frames, each containing an array of Keypoints
   fps?: number;
+  timestamps?: number[]; // Array of timestamps for each frame
   error?: string;
 }
 


### PR DESCRIPTION
Videos with Variable Frame Rate (VFR) drop synchronization when assuming a flat constant FPS. Extract exact frame timestamps from OpenCV and use them to binary search the correct pose data in the frontend viewer.